### PR TITLE
Reexport squirrel types

### DIFF
--- a/delete.go
+++ b/delete.go
@@ -23,7 +23,7 @@ func (b DeleteBuilder) Prefix(sql string, args ...interface{}) DeleteBuilder {
 }
 
 // PrefixExpr adds an expression to the very beginning of the query
-func (b DeleteBuilder) PrefixExpr(expr sq.Sqlizer) DeleteBuilder {
+func (b DeleteBuilder) PrefixExpr(expr Sqlizer) DeleteBuilder {
 	return b.withBuilder(b.builder.PrefixExpr(expr))
 }
 

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.18
 require (
 	github.com/Masterminds/squirrel v1.5.4
 	github.com/blockloop/scan v1.3.0
+	github.com/go-sql-driver/mysql v1.7.1
 	github.com/stretchr/testify v1.8.4
 )
 

--- a/go.sum
+++ b/go.sum
@@ -5,6 +5,8 @@ github.com/blockloop/scan v1.3.0/go.mod h1:qd+3w68+o7m5Xhj9X5SlJH2rbFyK8w0WT47Rk
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/go-sql-driver/mysql v1.7.1 h1:lUIinVbN1DY0xBg0eMOzmmtGoHwWBbvnWubQUrtU8EI=
+github.com/go-sql-driver/mysql v1.7.1/go.mod h1:OXbVy3sEdcQ2Doequ6Z5BW6fXNQTmx+9S1MCJN5yJMI=
 github.com/kr/pretty v0.2.1 h1:Fmg33tUaq4/8ym9TJN1x7sLJnHVwhP33CNkpYV/7rwI=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=

--- a/insert.go
+++ b/insert.go
@@ -23,7 +23,7 @@ func (b InsertBuilder) Prefix(sql string, args ...interface{}) InsertBuilder {
 }
 
 // PrefixExpr adds an expression to the very beginning of the query
-func (b InsertBuilder) PrefixExpr(expr sq.Sqlizer) InsertBuilder {
+func (b InsertBuilder) PrefixExpr(expr Sqlizer) InsertBuilder {
 	return b.withBuilder(b.builder.PrefixExpr(expr))
 }
 
@@ -48,7 +48,7 @@ func (b InsertBuilder) Suffix(sql string, args ...interface{}) InsertBuilder {
 }
 
 // SuffixExpr adds an expression to the end of the query
-func (b InsertBuilder) SuffixExpr(expr sq.Sqlizer) InsertBuilder {
+func (b InsertBuilder) SuffixExpr(expr Sqlizer) InsertBuilder {
 	return b.withBuilder(b.builder.SuffixExpr(expr))
 }
 

--- a/reexports.go
+++ b/reexports.go
@@ -1,0 +1,9 @@
+package sqx
+
+import sq "github.com/Masterminds/squirrel"
+
+type And = sq.And
+type Eq = sq.Eq
+type NotEq = sq.NotEq
+type Or = sq.Or
+type Sqlizer = sq.Sqlizer

--- a/select.go
+++ b/select.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+
 	sq "github.com/Masterminds/squirrel"
 	"github.com/blockloop/scan"
 )
@@ -27,7 +28,7 @@ func (b SelectBuilder[T]) Prefix(sql string, args ...interface{}) SelectBuilder[
 }
 
 // PrefixExpr adds an expression to the very beginning of the query
-func (b SelectBuilder[T]) PrefixExpr(expr sq.Sqlizer) SelectBuilder[T] {
+func (b SelectBuilder[T]) PrefixExpr(expr Sqlizer) SelectBuilder[T] {
 	return b.withBuilder(b.builder.PrefixExpr(expr))
 }
 
@@ -174,7 +175,7 @@ func (b SelectBuilder[T]) Suffix(sql string, rest ...interface{}) SelectBuilder[
 }
 
 // SuffixExpr adds an expression to the end of the query
-func (b SelectBuilder[T]) SuffixExpr(expr sq.Sqlizer) SelectBuilder[T] {
+func (b SelectBuilder[T]) SuffixExpr(expr Sqlizer) SelectBuilder[T] {
 	return b.withBuilder(b.builder.SuffixExpr(expr))
 }
 

--- a/sqx_test.go
+++ b/sqx_test.go
@@ -11,6 +11,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	_ "github.com/go-sql-driver/mysql"
 )
 
 type dbConfig struct {

--- a/toclause.go
+++ b/toclause.go
@@ -1,12 +1,11 @@
 package sqx
 
 import (
-	sq "github.com/Masterminds/squirrel"
 	scan "github.com/blockloop/scan"
 )
 
 type Clause struct {
-	contents sq.Eq
+	contents Eq
 	err      error
 }
 
@@ -21,7 +20,7 @@ func (c *Clause) ToSql() (string, []interface{}, error) {
 // ToClause converts a filter interface to a SQL Where clause by introspecting its db tags
 func ToClause(v any, excluded ...string) *Clause {
 	if isNil(v) {
-		return &Clause{contents: sq.Eq{}, err: nil}
+		return &Clause{contents: Eq{}, err: nil}
 	}
 	cols, err := scan.ColumnsStrict(v, excluded...)
 	if err != nil {
@@ -31,7 +30,7 @@ func ToClause(v any, excluded ...string) *Clause {
 	if err != nil {
 		return &Clause{contents: nil, err: err}
 	}
-	contents := sq.Eq{}
+	contents := Eq{}
 	for i := range cols {
 		if !isNil(vals[i]) {
 			contents[cols[i]] = vals[i]
@@ -46,7 +45,7 @@ func ToClauseAlias(tableName string, v any, excluded ...string) *Clause {
 	if clause.err != nil {
 		return clause
 	}
-	aliasedClause := &Clause{contents: sq.Eq{}, err: nil}
+	aliasedClause := &Clause{contents: Eq{}, err: nil}
 	for key, value := range clause.contents {
 		aliasedClause.contents[tableName+"."+key] = value
 	}

--- a/toclause_test.go
+++ b/toclause_test.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"testing"
 
-	sq "github.com/Masterminds/squirrel"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -37,7 +36,7 @@ func TestToClause(t *testing.T) {
 		IntCol: &[]int{1, 2},
 	}
 	t.Run("Can convert all fields of a struct to a map", func(t *testing.T) {
-		expected := sq.Eq{
+		expected := Eq{
 			"str_col": ptr("i am str"),
 			"int_col": &[]int{1, 2},
 		}
@@ -50,7 +49,7 @@ func TestToClause(t *testing.T) {
 		StrCol: ptr("still a str"),
 	}
 	t.Run("Omits unset fields", func(t *testing.T) {
-		expected := sq.Eq{
+		expected := Eq{
 			"str_col": ptr("still a str"),
 		}
 
@@ -59,13 +58,13 @@ func TestToClause(t *testing.T) {
 	})
 
 	t.Run("Returns empty on nil input", func(t *testing.T) {
-		expected := sq.Eq{}
+		expected := Eq{}
 
 		clause := ToClause(nil)
 		assert.Equal(t, expected, clause.contents)
 	})
 	t.Run("Returns empty on empty output", func(t *testing.T) {
-		expected := sq.Eq{}
+		expected := Eq{}
 
 		clause := ToClause(&thingyGetFilter{})
 		assert.Equal(t, expected, clause.contents)
@@ -77,7 +76,7 @@ func TestToClauseAlias(t *testing.T) {
 		StrCol: ptr("i am str"),
 		IntCol: &[]int{100},
 	}
-	expected := sq.Eq{
+	expected := Eq{
 		"table.str_col": ptr("i am str"),
 		"table.int_col": &[]int{100},
 	}

--- a/update.go
+++ b/update.go
@@ -25,7 +25,7 @@ func (b UpdateBuilder) Prefix(sql string, args ...interface{}) UpdateBuilder {
 }
 
 // PrefixExpr adds an expression to the very beginning of the query
-func (b UpdateBuilder) PrefixExpr(expr sq.Sqlizer) UpdateBuilder {
+func (b UpdateBuilder) PrefixExpr(expr Sqlizer) UpdateBuilder {
 	return b.withBuilder(b.builder.PrefixExpr(expr))
 }
 
@@ -79,7 +79,7 @@ func (b UpdateBuilder) Suffix(sql string, args ...interface{}) UpdateBuilder {
 }
 
 // SuffixExpr adds an expression to the end of the query
-func (b UpdateBuilder) SuffixExpr(expr sq.Sqlizer) UpdateBuilder {
+func (b UpdateBuilder) SuffixExpr(expr Sqlizer) UpdateBuilder {
 	return b.withBuilder(b.builder.SuffixExpr(expr))
 }
 

--- a/widget_test.go
+++ b/widget_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	sq "github.com/Masterminds/squirrel"
 	"github.com/stytchauth/sqx"
 )
 
@@ -59,7 +58,7 @@ func (d *dbWidget) Update(ctx context.Context, widgetID string, f *widgetUpdateF
 	}
 	return sqx.Write(ctx).
 		Update("sqx_widgets_test").
-		Where(sq.Eq{"widget_id": widgetID}).
+		Where(sqx.Eq{"widget_id": widgetID}).
 		SetMap(f.toSetMap()).
 		Debug().
 		Do()
@@ -69,7 +68,7 @@ func (d *dbWidget) GetByID(ctx context.Context, widgetID string) (*Widget, error
 	return sqx.Read[Widget](ctx).
 		Select("*").
 		From("sqx_widgets_test").
-		Where(sq.Eq{"widget_id": widgetID}).
+		Where(sqx.Eq{"widget_id": widgetID}).
 		Debug().
 		One()
 }


### PR DESCRIPTION
Reexport commonly used `squirrel` types (`Eq`, `And`, `Or`, etc.)

One question: this also adds a dependency on `go-sql-driver` which is *only* used for testing; is this a problem?