### PR TITLE
docs: Add example for how to use transactions. Rewrite sqx_test to match

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,12 +296,12 @@ func MyOperationThatNeedsATransaction(ctx context.Context) error {
 	// Defer a rollback in case anything fails.
 	defer tx.Rollback()
 	
-	err = OperationThatNeedsAQueryable(ctx, tx);
+	err = OperationThatNeedsAQueryable(ctx, tx)
 	if err != nil {
 		return err
 	}
 
-	err = OperationThatNeedsAQueryable(ctx, tx);
+	err = OperationThatNeedsAQueryable(ctx, tx)
 	if err != nil {
 		return err
 	}

--- a/widget_test.go
+++ b/widget_test.go
@@ -32,15 +32,17 @@ func newDBWidget() dbWidget {
 	return dbWidget{}
 }
 
-func (d *dbWidget) Create(ctx context.Context, w *Widget) error {
+func (d *dbWidget) Create(ctx context.Context, tx sqx.Queryable, w *Widget) error {
 	return sqx.Write(ctx).
+		WithQueryable(tx).
 		Insert("sqx_widgets_test").
 		SetMap(w.toSetMap()).
 		Do()
 }
 
-func (d *dbWidget) Delete(ctx context.Context, widgetID string) error {
+func (d *dbWidget) Delete(ctx context.Context, tx sqx.Queryable, widgetID string) error {
 	return sqx.Write(ctx).
+		WithQueryable(tx).
 		Delete("sqx_widgets_test").
 		Where(sqx.Eq{"widget_id": widgetID}).
 		Do()
@@ -59,16 +61,18 @@ func (w *widgetUpdateFilter) toSetMap() (map[string]any, error) {
 	return sqx.ToSetMap(w)
 }
 
-func (d *dbWidget) Update(ctx context.Context, widgetID string, f *widgetUpdateFilter) error {
+func (d *dbWidget) Update(ctx context.Context, tx sqx.Queryable, widgetID string, f *widgetUpdateFilter) error {
 	return sqx.Write(ctx).
+		WithQueryable(tx).
 		Update("sqx_widgets_test").
 		Where(sqx.Eq{"widget_id": widgetID}).
 		SetMap(f.toSetMap()).
 		Do()
 }
 
-func (d *dbWidget) GetByID(ctx context.Context, widgetID string) (*Widget, error) {
+func (d *dbWidget) GetByID(ctx context.Context, tx sqx.Queryable, widgetID string) (*Widget, error) {
 	return sqx.Read[Widget](ctx).
+		WithQueryable(tx).
 		Select("*").
 		From("sqx_widgets_test").
 		Where(sqx.Eq{"widget_id": widgetID}).
@@ -80,16 +84,18 @@ type widgetGetFilter struct {
 	Status   *string   `db:"status"`
 }
 
-func (d *dbWidget) Get(ctx context.Context, f *widgetGetFilter) ([]Widget, error) {
+func (d *dbWidget) Get(ctx context.Context, tx sqx.Queryable, f *widgetGetFilter) ([]Widget, error) {
 	return sqx.Read[Widget](ctx).
+		WithQueryable(tx).
 		Select("*").
 		From("sqx_widgets_test").
 		Where(sqx.ToClause(f)).
 		All()
 }
 
-func (d *dbWidget) GetAll(ctx context.Context) ([]Widget, error) {
+func (d *dbWidget) GetAll(ctx context.Context, tx sqx.Queryable) ([]Widget, error) {
 	return sqx.Read[Widget](ctx).
+		WithQueryable(tx).
 		Select("*").
 		From("sqx_widgets_test").
 		OrderBy("widget_id DESC").


### PR DESCRIPTION
Closes #27

`sqx` doesn't want to handle running `Begin`/`Commit`/`Rollback` today - that should be handled separately. Added docs showing an example usecase, and rewrote `sqx_test` to use `WithQueryable(tx)` instead of `sqx.SetDefaultQueryable(tx)`, which was always a bit silly as an example.