### PR TITLE
[WIP] chore: Add Postgres support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,8 @@ help:
 .PHONY: tests
 .PHONY: test
 tests test: # Runs unit tests
-	go test
+	DB=MYSQL go test
+	DB=POSTGRES go test
 
 .PHONY: lint
 lint: # Run the linter and auto-fix issues where possible

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,8 +7,6 @@ services:
     command:
       # Ensure a consistent timezone for timestamps by running in UTC.
       - '--default-time-zone=+00:00'
-      # The SQL mode must match the RDS settings in the platform repo. You can also check this by
-      # running `SELECT @@SQL_MODE`.
       - '--sql-mode=STRICT_TRANS_TABLES,STRICT_ALL_TABLES'
 
     ports:
@@ -19,3 +17,14 @@ services:
       MYSQL_USER: sqx
       MYSQL_PASSWORD: sqx
       MYSQL_DATABASE: sqx
+  postgres:
+    # Required to make the mysql image function on the M1 macs
+    platform: linux/x86_64
+    image: postgres:12.16
+    ports:
+      - "4307:5432"
+    environment:
+      # This is only for local development, so these insecure settings are fine.
+      POSTGRES_USER: sqx
+      POSTGRES_PASSWORD: sqx
+      POSTGRES_DB: sqx

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/kr/text v0.1.0 // indirect
 	github.com/lann/builder v0.0.0-20180802200727-47ae307949d0 // indirect
 	github.com/lann/ps v0.0.0-20150810152359-62de8c46ede0 // indirect
+	github.com/lib/pq v1.10.9 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	golang.org/x/text v0.12.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -14,6 +14,8 @@ github.com/lann/builder v0.0.0-20180802200727-47ae307949d0 h1:SOEGU9fKiNWd/HOJuq
 github.com/lann/builder v0.0.0-20180802200727-47ae307949d0/go.mod h1:dXGbAdH5GtBTC4WfIxhKZfyBF/HBFgRZSWwZ9g/He9o=
 github.com/lann/ps v0.0.0-20150810152359-62de8c46ede0 h1:P6pPBnrTSX3DEVR4fDembhRWSsG5rVo6hYhAB/ADZrk=
 github.com/lann/ps v0.0.0-20150810152359-62de8c46ede0/go.mod h1:vmVJ0l/dxyfGW6FmdpVm2joNMFikkuWg0EoCKLGUMNw=
+github.com/lib/pq v1.10.9 h1:YXG7RB+JIjhP29X+OtkiDnYaXQwpS4JEWq7dtCCRUEw=
+github.com/lib/pq v1.10.9/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/proullon/ramsql v0.0.1 h1:tI7qN48Oj1LTmgdo4aWlvI9z45a4QlWaXlmdJ+IIfbU=

--- a/placeholder.go
+++ b/placeholder.go
@@ -1,0 +1,37 @@
+package sqx
+
+import sq "github.com/stytchauth/squirrel"
+
+// PlaceholderFormat is the interface that wraps the ReplacePlaceholders method.
+//
+// ReplacePlaceholders takes a SQL statement and replaces each question mark
+// placeholder with a (possibly different) SQL placeholder.
+type PlaceholderFormat sq.PlaceholderFormat
+
+var (
+	// Question is a PlaceholderFormat instance that leaves placeholders as
+	// question marks.
+	Question = sq.Question
+
+	// Dollar is a PlaceholderFormat instance that replaces placeholders with
+	// dollar-prefixed positional placeholders (e.g. $1, $2, $3).
+	Dollar = sq.Dollar
+
+	// Colon is a PlaceholderFormat instance that replaces placeholders with
+	// colon-prefixed positional placeholders (e.g. :1, :2, :3).
+	Colon = sq.Colon
+
+	// AtP is a PlaceholderFormat instance that replaces placeholders with
+	// "@p"-prefixed positional placeholders (e.g. @p1, @p2, @p3).
+	AtP = sq.AtP
+
+	defaultPlaceholderFormat sq.PlaceholderFormat = Question
+)
+
+func SetPlaceholder(placeholderFormat PlaceholderFormat) {
+	defaultPlaceholderFormat = placeholderFormat
+}
+
+func SetPostgres() {
+	SetPlaceholder(Dollar)
+}

--- a/sqx.go
+++ b/sqx.go
@@ -57,22 +57,26 @@ func Write(ctx context.Context) runCtx {
 
 // Select constructs a new SelectBuilder for the given columns for this typedRunCtx.
 func (rc typedRunCtx[T]) Select(columns ...string) SelectBuilder[T] {
-	return SelectBuilder[T]{builder: sq.Select(columns...), queryable: rc.queryable, logger: rc.logger, ctx: rc.ctx}
+	builder := sq.Select(columns...).PlaceholderFormat(defaultPlaceholderFormat)
+	return SelectBuilder[T]{builder: builder, queryable: rc.queryable, logger: rc.logger, ctx: rc.ctx}
 }
 
 // Update constructs a new UpdateBuilder for the given table for this typedRunCtx.
 func (rc runCtx) Update(table string) UpdateBuilder {
-	return UpdateBuilder{builder: sq.Update(table), queryable: rc.queryable, logger: rc.logger, ctx: rc.ctx}
+	builder := sq.Update(table).PlaceholderFormat(defaultPlaceholderFormat)
+	return UpdateBuilder{builder: builder, queryable: rc.queryable, logger: rc.logger, ctx: rc.ctx}
 }
 
 // Insert constructs a new InsertBuilder for the given table for this typedRunCtx.
 func (rc runCtx) Insert(table string) InsertBuilder {
-	return InsertBuilder{builder: sq.Insert(table), queryable: rc.queryable, logger: rc.logger, ctx: rc.ctx}
+	builder := sq.Insert(table).PlaceholderFormat(defaultPlaceholderFormat)
+	return InsertBuilder{builder: builder, queryable: rc.queryable, logger: rc.logger, ctx: rc.ctx}
 }
 
 // Delete constructs a new DeleteBuilder for the given table for this typedRunCtx.
 func (rc runCtx) Delete(table string) DeleteBuilder {
-	return DeleteBuilder{builder: sq.Delete(table), queryable: rc.queryable, logger: rc.logger, ctx: rc.ctx}
+	builder := sq.Delete(table).PlaceholderFormat(defaultPlaceholderFormat)
+	return DeleteBuilder{builder: builder, queryable: rc.queryable, logger: rc.logger, ctx: rc.ctx}
 }
 
 // runShim maps a Queryable to the squirrel.BaseRunner interface


### PR DESCRIPTION
Adds Postgres support + set of integration tests.

WIP because our forked DeleteBuilder doesn't play well with Postgres - 

```
	// For DELETE JOINs, we need to say where we're deleting from.
	// DELETE FROM X doesn't do that on its own, so we now query
	// with DELETE X FROM X which is safe for non-JOIN queries.
	sql.WriteString("DELETE ")
	sql.WriteString(d.From)
```

We generate `DELETE tablename FROM tablename` with is invalid Postgres syntax. It looks like we'll need to fix this :bug: upstream first.