### PR TITLE
Add DoResult to retrieve affected rows / last insert ID

### DIFF
--- a/delete.go
+++ b/delete.go
@@ -2,6 +2,7 @@ package sqx
 
 import (
 	"context"
+	"database/sql"
 	"fmt"
 
 	sq "github.com/stytchauth/squirrel"
@@ -68,14 +69,20 @@ func (b DeleteBuilder) Suffix(sql string, args ...interface{}) DeleteBuilder {
 
 // Do executes the DeleteBuilder
 func (b DeleteBuilder) Do() error {
+	_, err := b.DoResult()
+	return err
+}
+
+// DoResult executes the DeleteBuilder and also returns the sql.Result for a successful query. This is useful if you
+// wish to check the value of the LastInsertId() or RowsAffected() methods since Do() will discard this information.
+func (b DeleteBuilder) DoResult() (sql.Result, error) {
 	if b.err != nil {
-		return b.err
+		return nil, b.err
 	}
 	if b.queryable == nil {
-		return fmt.Errorf("missing queryable - call SetDefaultQueryable or WithQueryable to set it")
+		return nil, fmt.Errorf("missing queryable - call SetDefaultQueryable or WithQueryable to set it")
 	}
-	_, err := b.builder.RunWith(runShim{b.queryable}).ExecContext(b.ctx)
-	return err
+	return b.builder.RunWith(runShim{b.queryable}).ExecContext(b.ctx)
 }
 
 // Debug prints the DeleteBuilder state out to the provided logger

--- a/empty_result.go
+++ b/empty_result.go
@@ -1,0 +1,13 @@
+package sqx
+
+// EmptyResult represents a result with no rows affected.
+// This is used for an UpdateBuilder that has no pending changes since the query would be a noop.
+type EmptyResult struct{}
+
+func (e EmptyResult) LastInsertId() (int64, error) {
+	return 0, nil
+}
+
+func (e EmptyResult) RowsAffected() (int64, error) {
+	return 0, nil
+}

--- a/insert.go
+++ b/insert.go
@@ -2,6 +2,7 @@ package sqx
 
 import (
 	"context"
+	"database/sql"
 	"fmt"
 
 	sq "github.com/stytchauth/squirrel"
@@ -72,14 +73,20 @@ func (b InsertBuilder) SetMap(clauses map[string]interface{}, errors ...error) I
 
 // Do executes the InsertBuilder
 func (b InsertBuilder) Do() error {
+	_, err := b.DoResult()
+	return err
+}
+
+// DoResult executes the InsertBuilder and also returns the sql.Result for a successful query. This is useful if you
+// wish to check the value of the LastInsertId() or RowsAffected() methods since Do() will discard this information.
+func (b InsertBuilder) DoResult() (sql.Result, error) {
 	if b.err != nil {
-		return b.err
+		return nil, b.err
 	}
 	if b.queryable == nil {
-		return fmt.Errorf("missing queryable - call SetDefaultQueryable or WithQueryable to set it")
+		return nil, fmt.Errorf("missing queryable - call SetDefaultQueryable or WithQueryable to set it")
 	}
-	_, err := b.builder.RunWith(runShim{b.queryable}).ExecContext(b.ctx)
-	return err
+	return b.builder.RunWith(runShim{b.queryable}).ExecContext(b.ctx)
 }
 
 // Debug prints the InsertBuilder state out to the provided logger

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package sqx
 
-const VERSION = "0.1.0"
+const VERSION = "0.2.0"

--- a/widget_test.go
+++ b/widget_test.go
@@ -2,6 +2,7 @@ package sqx_test
 
 import (
 	"context"
+	"database/sql"
 	"fmt"
 
 	"github.com/stytchauth/sqx"
@@ -62,12 +63,17 @@ func (w *widgetUpdateFilter) toSetMap() (map[string]any, error) {
 }
 
 func (d *dbWidget) Update(ctx context.Context, tx sqx.Queryable, widgetID string, f *widgetUpdateFilter) error {
+	_, err := d.UpdateResult(ctx, tx, widgetID, f)
+	return err
+}
+
+func (d *dbWidget) UpdateResult(ctx context.Context, tx sqx.Queryable, widgetID string, f *widgetUpdateFilter) (sql.Result, error) {
 	return sqx.Write(ctx).
 		WithQueryable(tx).
 		Update("sqx_widgets_test").
 		Where(sqx.Eq{"widget_id": widgetID}).
 		SetMap(f.toSetMap()).
-		Do()
+		DoResult()
 }
 
 func (d *dbWidget) GetByID(ctx context.Context, tx sqx.Queryable, widgetID string) (*Widget, error) {


### PR DESCRIPTION
# Summary
This PR adds a `DoResult` function for cases when you want the underlying `sql.Result`. This is useful if, for example, you want to know the number of rows affected in a query, since otherwise this gets discarded by `Do()`.

# Testing
I added two new test in `sqx_test.go` to display this behavior
1. When zero rows affected, UpdateResult returns a result with 0 rows (tested the "No updates" case)
2. When >0 rows affected, UpdateResult returns a result with the expected number of affected rows