### PR TITLE
Raise an error if given a struct with no tags

### DIFF
--- a/reexports.go
+++ b/reexports.go
@@ -16,3 +16,15 @@ type Or = sq.Or
 
 // Sqlizer is an interface containing the ToSql method. It is a re-export of squirrel.Sqlizer.
 type Sqlizer = sq.Sqlizer
+
+// Gt represents a SQL > expression. It is a re-export of squirrel.Gt.
+type Gt = sq.Gt
+
+// GtOrEq represents a SQL >= expression. It is a re-export of squirrel.GtOrEq.
+type GtOrEq = sq.GtOrEq
+
+// Lt represents a SQL < expression. It is a re-export of squirrel.Lt.
+type Lt = sq.Lt
+
+// LtOrEq represents a SQL <= expression. It is a re-export of squirrel.LtOrEq.
+type LtOrEq = sq.LtOrEq

--- a/toclause.go
+++ b/toclause.go
@@ -1,8 +1,12 @@
 package sqx
 
 import (
+	"errors"
+
 	scan "github.com/blockloop/scan/v2"
 )
+
+var NoDBTagsError = errors.New("No db tags detected")
 
 // Clause stores an Eq result, but also holds an error if one occurred during the conversion. You may think of this
 // struct as a (Eq, error) tuple that implements the Sqlizer interface.
@@ -27,6 +31,9 @@ func ToClause(v any, excluded ...string) *Clause {
 	cols, err := scan.ColumnsStrict(v, excluded...)
 	if err != nil {
 		return &Clause{contents: nil, err: err}
+	}
+	if len(cols) == 0 {
+		return &Clause{contents: nil, err: NoDBTagsError}
 	}
 	vals, err := scan.Values(cols, v)
 	if err != nil {

--- a/toclause_test.go
+++ b/toclause_test.go
@@ -28,6 +28,11 @@ type thingyGetFilter struct {
 	IntCol *[]int  `db:"int_col"`
 }
 
+type thingyGetFilterWithNoTags struct {
+	StrCol *string
+	IntCol *[]int
+}
+
 func TestToClause(t *testing.T) {
 	filter := thingyGetFilter{
 		StrCol: Ptr("i am str"),
@@ -66,6 +71,11 @@ func TestToClause(t *testing.T) {
 
 		clause := ToClause(&thingyGetFilter{})
 		assert.Equal(t, expected, clause.contents)
+	})
+
+	t.Run("Has an error if given a struct with no db tags", func(t *testing.T) {
+		clause := ToClause(&thingyGetFilterWithNoTags{})
+		assert.Error(t, clause.err)
 	})
 }
 

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package sqx
 
-const VERSION = "0.2.0"
+const VERSION = "0.3.0"


### PR DESCRIPTION
1. Reexports of Gt, GtOrEq, Lt, and LtOrEq
2. Adds an error if asked to build clauses using an interface without `db` tags.