### PR TITLE
Fix bug with First

### DIFF
--- a/select.go
+++ b/select.go
@@ -266,13 +266,13 @@ func (b SelectBuilder[T]) First() (*T, error) {
 		return nil, err
 	}
 
-	var dest *T
-	err = scan.RowStrict(dest, rows)
+	var dest T
+	err = scan.RowStrict(&dest, rows)
 	if err != nil {
 		return nil, err
 	}
 
-	return dest, nil
+	return &dest, nil
 }
 
 // FirstScalar is like First but dereferences the result into a scalar value. If an error is raised, the scalar value

--- a/sqx_test.go
+++ b/sqx_test.go
@@ -167,6 +167,37 @@ func TestInsert(t *testing.T) {
 	})
 }
 
+func TestSelect(t *testing.T) {
+	ctx := context.Background()
+
+	w1 := newWidget("great")
+	w2 := newWidget("fine")
+
+	t.Run("First returns either w1 or w2", func(t *testing.T) {
+		tx := Tx(t)
+		setupTestWidgetsTable(t, tx)
+		dbWidget := newDBWidget()
+		require.NoError(t, dbWidget.Create(ctx, tx, &w1))
+		require.NoError(t, dbWidget.Create(ctx, tx, &w2))
+
+		w, err := dbWidget.First(ctx, tx, &widgetGetFilter{})
+
+		require.NoError(t, err)
+		assert.True(t, *w == w1 || *w == w2)
+	})
+
+	t.Run("First returns an error when no rows are found", func(t *testing.T) {
+		tx := Tx(t)
+		setupTestWidgetsTable(t, tx)
+		dbWidget := newDBWidget()
+
+		_, err := dbWidget.First(ctx, tx, &widgetGetFilter{})
+
+		assert.Error(t, err)
+		assert.EqualError(t, sql.ErrNoRows, err.Error())
+	})
+}
+
 func TestDelete(t *testing.T) {
 	// Arrange
 	ctx := context.Background()

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package sqx
 
-const VERSION = "0.3.0"
+const VERSION = "0.4.0"

--- a/widget_test.go
+++ b/widget_test.go
@@ -26,8 +26,7 @@ func (w Widget) toSetMap() (map[string]any, error) {
 	return sqx.ToSetMap(&w)
 }
 
-type dbWidget struct {
-}
+type dbWidget struct{}
 
 func newDBWidget() dbWidget {
 	return dbWidget{}
@@ -97,6 +96,15 @@ func (d *dbWidget) Get(ctx context.Context, tx sqx.Queryable, f *widgetGetFilter
 		From("sqx_widgets_test").
 		Where(sqx.ToClause(f)).
 		All()
+}
+
+func (d *dbWidget) First(ctx context.Context, tx sqx.Queryable, f *widgetGetFilter) (*Widget, error) {
+	return sqx.Read[Widget](ctx).
+		WithQueryable(tx).
+		Select("*").
+		From("sqx_widgets_test").
+		Where(sqx.ToClause(f)).
+		First()
 }
 
 func (d *dbWidget) GetAll(ctx context.Context, tx sqx.Queryable) ([]Widget, error) {


### PR DESCRIPTION
We were missing a test for `First` and realized that it was definitely *not* working. This PR fixes the behavior and adds a test.

Without the change:
```
=== Failed
=== FAIL: . TestSelect/First_returns_either_w1_or_w2 (0.05s)

=== FAIL: . TestSelect (0.05s)
panic: reflect: call of reflect.Value.Set on zero Value [recovered]
        panic: reflect: call of reflect.Value.Set on zero Value

```

With the change, the tests pass.