### PR TITLE
[WIP] FromItems support

### DIFF
--- a/insertmany.go
+++ b/insertmany.go
@@ -1,0 +1,110 @@
+package sqx
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+
+	"github.com/blockloop/scan/v2"
+	sq "github.com/stytchauth/squirrel"
+)
+
+// InsertManyBuilder wraps squirrel.InsertBuilder and adds syntactic sugar for common usage patterns.
+// This is a special case that includes a type constraint since generic methods are not supported in Go.
+// In order to implement FromItems, we need a type constraint, but this is only possible if the struct itself
+// is also generic. As such, the InsertManyBuilder is more constrained than InsertBuilder, but this is by
+// design since *most* use cases should prefer the InsertBuilder unless they explicitly want to use FromItems.
+type InsertManyBuilder[T any] struct {
+	builder   sq.InsertBuilder
+	queryable Queryable
+	ctx       context.Context
+	err       error
+	logger    Logger
+}
+
+// ============================================
+// BEGIN: squirrel-InsertBuilder parity section
+// ============================================
+
+// Columns adds insert columns to the query.
+func (b InsertManyBuilder[T]) Columns(columns ...string) InsertManyBuilder[T] {
+	return b.withBuilder(b.builder.Columns(columns...))
+}
+
+// Values adds a single row's values to the query.
+func (b InsertManyBuilder[T]) Values(values ...any) InsertManyBuilder[T] {
+	return b.withBuilder(b.builder.Values(values...))
+}
+
+// ==========================================
+// END: squirrel-InsertBuilder parity section
+// ==========================================
+
+// FromItems generates an InsertManyBuilder from a slice of items. The first item in the slice is used to determine the
+// columns for the insert statement. If excluded columns are provided, they will be removed from the list of columns.
+// All items should be of the same type.
+func (b InsertManyBuilder[T]) FromItems(items []T, excluded ...string) InsertManyBuilder[T] {
+	if len(items) == 0 {
+		return b
+	}
+
+	cols, err := scan.ColumnsStrict(&items[0], excluded...)
+	if err != nil {
+		return b.withError(err)
+	}
+
+	b = b.Columns(cols...)
+	for _, item := range items {
+		vals, err := scan.Values(cols, &item)
+		if err != nil {
+			return b.withError(err)
+		}
+		b = b.Values(vals...)
+	}
+	return b
+}
+
+// Do executes the InsertManyBuilder
+func (b InsertManyBuilder[T]) Do() error {
+	_, err := b.DoResult()
+	return err
+}
+
+// DoResult executes the InsertManyBuilder and also returns the sql.Result for a successful query. This is useful if you
+// wish to check the value of the LastInsertId() or RowsAffected() methods since Do() will discard this information.
+func (b InsertManyBuilder[T]) DoResult() (sql.Result, error) {
+	if b.err != nil {
+		return nil, b.err
+	}
+	if b.queryable == nil {
+		return nil, fmt.Errorf("missing queryable - call SetDefaultQueryable or WithQueryable to set it")
+	}
+	return b.builder.RunWith(runShim{b.queryable}).ExecContext(b.ctx)
+}
+
+// Debug prints the InsertManyBuilder state out to the provided logger
+func (b InsertManyBuilder[T]) Debug() InsertManyBuilder[T] {
+	debug(b.logger, b.builder)
+	return b
+}
+
+// WithQueryable configures a Queryable for this InsertManyBuilder instance
+func (b InsertManyBuilder[T]) WithQueryable(queryable Queryable) InsertManyBuilder[T] {
+	return InsertManyBuilder[T]{builder: b.builder, queryable: queryable, logger: b.logger, ctx: b.ctx, err: b.err}
+}
+
+// WithLogger configures a Queryable for this InsertManyBuilder instance
+func (b InsertManyBuilder[T]) WithLogger(logger Logger) InsertManyBuilder[T] {
+	return InsertManyBuilder[T]{builder: b.builder, queryable: b.queryable, logger: logger, ctx: b.ctx, err: b.err}
+}
+
+func (b InsertManyBuilder[T]) withError(err error) InsertManyBuilder[T] {
+	if b.err != nil {
+		return b
+	}
+	return InsertManyBuilder[T]{builder: b.builder, queryable: b.queryable, logger: b.logger, ctx: b.ctx, err: err}
+}
+
+func (b InsertManyBuilder[T]) withBuilder(builder sq.InsertBuilder) InsertManyBuilder[T] {
+	return InsertManyBuilder[T]{builder: builder, queryable: b.queryable, logger: b.logger, ctx: b.ctx, err: b.err}
+}

--- a/sqx.go
+++ b/sqx.go
@@ -55,6 +55,10 @@ func Write(ctx context.Context) runCtx {
 	}
 }
 
+func TypedWrite[T any](ctx context.Context) typedRunCtx[T] {
+	return typedRunCtx[T]{Write(ctx)}
+}
+
 // Select constructs a new SelectBuilder for the given columns for this typedRunCtx.
 func (rc typedRunCtx[T]) Select(columns ...string) SelectBuilder[T] {
 	return SelectBuilder[T]{builder: sq.Select(columns...), queryable: rc.queryable, logger: rc.logger, ctx: rc.ctx}
@@ -68,6 +72,10 @@ func (rc runCtx) Update(table string) UpdateBuilder {
 // Insert constructs a new InsertBuilder for the given table for this typedRunCtx.
 func (rc runCtx) Insert(table string) InsertBuilder {
 	return InsertBuilder{builder: sq.Insert(table), queryable: rc.queryable, logger: rc.logger, ctx: rc.ctx}
+}
+
+func (rc typedRunCtx[T]) InsertMany(table string) InsertManyBuilder[T] {
+	return InsertManyBuilder[T]{builder: sq.Insert(table), queryable: rc.queryable, logger: rc.logger, ctx: rc.ctx}
 }
 
 // Delete constructs a new DeleteBuilder for the given table for this typedRunCtx.

--- a/sqx_test.go
+++ b/sqx_test.go
@@ -139,6 +139,21 @@ func TestRead(t *testing.T) {
 		_, err := dbWidget.GetByID(ctx, tx, w1.ID)
 		assert.EqualError(t, expected, err.Error())
 	})
+
+	t.Run("Succeeds when multiple widgets are written at once", func(t *testing.T) {
+		w3 := newWidget("alright")
+		w4 := newWidget("okay")
+		err := dbWidget.CreateMany(ctx, tx, []Widget{w3, w4})
+		assert.NoError(t, err)
+
+		w3Read, err := dbWidget.GetByID(ctx, tx, w3.ID)
+		assert.NoError(t, err)
+		w4Read, err := dbWidget.GetByID(ctx, tx, w4.ID)
+		assert.NoError(t, err)
+
+		assert.Equal(t, &w3, w3Read)
+		assert.Equal(t, &w4, w4Read)
+	})
 }
 
 func TestInsert(t *testing.T) {

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package sqx
 
-const VERSION = "0.4.0"
+const VERSION = "0.5.0"

--- a/widget_test.go
+++ b/widget_test.go
@@ -40,6 +40,14 @@ func (d *dbWidget) Create(ctx context.Context, tx sqx.Queryable, w *Widget) erro
 		Do()
 }
 
+func (d *dbWidget) CreateMany(ctx context.Context, tx sqx.Queryable, ws []Widget) error {
+	return sqx.TypedWrite[Widget](ctx).
+		WithQueryable(tx).
+		InsertMany("sqx_widgets_test").
+		FromItems(ws).
+		Do()
+}
+
 func (d *dbWidget) Delete(ctx context.Context, tx sqx.Queryable, widgetID string) error {
 	return sqx.Write(ctx).
 		WithQueryable(tx).


### PR DESCRIPTION
The big challenge here is that we need strong typing in the call to FromItems which requires a typedRunCtx. As such, I had to create a new InsertManyBuilder[T any] to create the initial context in a typed way. Since generic methods aren't a thing in Go, I couldn't think of a better way to do this (you can't convert []T to []any naively).

See the new function in widget_test.go for how this looks. I'd like some discussion from others to help bikeshed this, though.