### PR TITLE
Add a tag to exclude on insert

### DIFF
--- a/insertmany.go
+++ b/insertmany.go
@@ -48,6 +48,14 @@ func (b InsertManyBuilder[T]) FromItems(items []T, excluded ...string) InsertMan
 		return b
 	}
 
+	model, err := reflectValue(&items[0])
+	if err != nil {
+		return b.withError(err)
+	}
+
+	newExclusions := excludedTags(model)
+	excluded = append(excluded, newExclusions...)
+
 	cols, err := scan.ColumnsStrict(&items[0], excluded...)
 	if err != nil {
 		return b.withError(err)

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package sqx
 
-const VERSION = "0.5.0"
+const VERSION = "0.6.0"

--- a/widget_test.go
+++ b/widget_test.go
@@ -4,15 +4,17 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"time"
 
 	"github.com/stytchauth/sqx"
 )
 
 type Widget struct {
-	ID      string  `db:"widget_id"`
-	Status  string  `db:"status"`
-	Enabled bool    `db:"enabled"`
-	OwnerID *string `db:"owner_id"`
+	ID        string     `db:"widget_id"`
+	Status    string     `db:"status"`
+	Enabled   bool       `db:"enabled"`
+	OwnerID   *string    `db:"owner_id"`
+	CreatedAt *time.Time `db:"created_at" sqx:"excludeOnInsert"`
 }
 
 func (w Widget) toSetMap() (map[string]any, error) {


### PR DESCRIPTION
Another potential QoL change: adds support for an excludeOnInsert tag for fields like CreatedAt/UpdatedAt that you want to *read* from the db, but never want to *write* to the db. This is an alternative to explicitly adding the column to the `exclude` field in certain locations.