### PR TITLE
[part of INFRA-2202][cleanup] Remove docker compose version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.9"
 services:
   mysql:
     # Required to make the mysql image function on the M1 macs


### PR DESCRIPTION
[No longer needed](https://docs.docker.com/reference/compose-file/version-and-name/#version-top-level-element-obsolete).