### PR TITLE
[fix] `SelectBuilder` now propagates `Clause` errors to the caller

### DIFF
--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package sqx
 
-const VERSION = "0.8.0"
+const VERSION = "0.9.0"


### PR DESCRIPTION
- If a `Clause` is passed to the `Where` method on the `SelectBuilder` then check it for errors and, if one is present, attach it to the builder and return it when the `query` method is invoked.